### PR TITLE
(chore) O3-3551: Use latest Actions in GH Actions

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -21,13 +21,13 @@ jobs:
       JAVA_VERSION: ${{ matrix.java-version }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up JDK
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java-version }}
       - name: Cache local Maven repository
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}


### PR DESCRIPTION
https://openmrs.atlassian.net/browse/O3-3551

Most of our repositories currently use actions/setup-java@v3 for Java setup and actions/checkout@v3 for code checkout within our CI pipelines. However, updated versions, actions/setup-java@v4 and actions/checkout@v4, are now available and should be considered for adoption across our projects.